### PR TITLE
Ignore blacklisted elements when using cfi offset to get element

### DIFF
--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -736,10 +736,23 @@ export function getTextTerminusInfoWithPartialCFI(
   );
 
   // Return the element at the end of the CFI
+  let startOffset;
+  let startElement = $currElement[0];
   const textOffset = parseInt(CFIAST.cfiString.localPath.termStep.offsetValue, 10);
+  if ((textOffset || textOffset === 0) && !Number.isNaN(textOffset)) {
+    startOffset = textOffset;
+    for (let i = 0; i < $currElement.length; i += 1) {
+      startElement = $currElement[i];
+      if (startElement.length < startOffset) {
+        startOffset -= startElement.length;
+      } else {
+        break;
+      }
+    }
+  }
   return {
-    textNode: $currElement[0],
-    textOffset,
+    textNode: startElement,
+    textOffset: startOffset,
   };
 }
 
@@ -774,10 +787,23 @@ export function getTextTerminusInfo(
   );
 
   // Return the element at the end of the CFI
+  let startOffset;
+  let startElement = $currElement[0];
   const textOffset = parseInt(CFIAST.cfiString.localPath.termStep.offsetValue, 10);
+  if ((textOffset || textOffset === 0) && !Number.isNaN(textOffset)) {
+    startOffset = textOffset;
+    for (let i = 0; i < $currElement.length; i += 1) {
+      startElement = $currElement[i];
+      if (startElement.length < startOffset) {
+        startOffset -= startElement.length;
+      } else {
+        break;
+      }
+    }
+  }
   return {
-    textNode: $currElement[0],
-    textOffset,
+    textNode: startElement,
+    textOffset: startOffset,
   };
 }
 

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -739,7 +739,9 @@ export function getTextTerminusInfoWithPartialCFI(
   let startOffset;
   let startElement = $currElement[0];
   const textOffset = parseInt(CFIAST.cfiString.localPath.termStep.offsetValue, 10);
-  if ((textOffset || textOffset === 0) && !Number.isNaN(textOffset)) {
+
+  // null check and NaN check
+  if ((textOffset || textOffset === 0) && !isNaN(textOffset)) {
     startOffset = textOffset;
     for (let i = 0; i < $currElement.length; i += 1) {
       startElement = $currElement[i];
@@ -790,7 +792,9 @@ export function getTextTerminusInfo(
   let startOffset;
   let startElement = $currElement[0];
   const textOffset = parseInt(CFIAST.cfiString.localPath.termStep.offsetValue, 10);
-  if ((textOffset || textOffset === 0) && !Number.isNaN(textOffset)) {
+
+  // null check and NaN check
+  if ((textOffset || textOffset === 0) && !isNaN(textOffset)) {
     startOffset = textOffset;
     for (let i = 0; i < $currElement.length; i += 1) {
       startElement = $currElement[i];

--- a/test/specs/interpreter.spec.js
+++ b/test/specs/interpreter.spec.js
@@ -257,6 +257,41 @@ describe('CFI INTERPRETER OBJECT', () => {
     expect(result.data).toEqual('67');
   });
 
+  it('can get previously injected text node of blacklisted elements', () => {
+    // the assumption here being that the .cfi-marker elements have been injected
+    // and split up the text node '0123456789'
+
+    const dom =
+      '<html>' +
+      '<div></div>' +
+      '<div>' +
+      "<div id='startParent'>" +
+      '0' +
+      "<span class='cfi-marker' id='start'></span>" +
+      '12345' +
+      "<span class='cfi-marker' id='end'></span>" +
+      '6789' +
+      '</div>' +
+      '</div>' +
+      '<div></div>' +
+      '</html>';
+
+    const $dom = $(new window.DOMParser().parseFromString(dom, 'text/xml'));
+
+    const CFI = 'epubcfi(/6/14!/4/2[startParent]/1:8)';
+
+    const textTerminusResult = Interpreter.getTextTerminusInfo(
+      CFI,
+      $dom[0],
+      ['cfi-marker'],
+      [],
+      [],
+    );
+
+    expect(textTerminusResult.textNode.wholeText).toEqual('6789');
+    expect(textTerminusResult.textOffset).toEqual(2);
+  });
+
   it('returns a text node CFI target', () => {
     const CFI = 'epubcfi(/6/14!/4/2/14/1:4)';
     const textNode = 3;
@@ -426,6 +461,41 @@ describe('CFI INTERPRETER OBJECT', () => {
 
       expect(textNode.nodeType).toBe(textNodeType);
       expect(textOffset).toBe(4);
+    });
+
+    it('can get previously injected text node of blacklisted elements using partial cfi', () => {
+      // the assumption here being that the .cfi-marker elements have been injected
+      // and split up the text node '0123456789'
+
+      const dom =
+        '<html>' +
+        '<div></div>' +
+        '<div>' +
+        "<div id='startParent'>" +
+        '0' +
+        "<span class='cfi-marker' id='start'></span>" +
+        '12345' +
+        "<span class='cfi-marker' id='end'></span>" +
+        '6789' +
+        '</div>' +
+        '</div>' +
+        '<div></div>' +
+        '</html>';
+
+      const $dom = $(new window.DOMParser().parseFromString(dom, 'text/xml'));
+
+      const CFI = 'epubcfi(/4/2[startParent]/1:8)';
+
+      const textTerminusResult = Interpreter.getTextTerminusInfoWithPartialCFI(
+        CFI,
+        $dom[0],
+        ['cfi-marker'],
+        [],
+        [],
+      );
+
+      expect(textTerminusResult.textNode.wholeText).toEqual('6789');
+      expect(textTerminusResult.textOffset).toEqual(2);
     });
   });
 


### PR DESCRIPTION
This change traverses multiple text nodes when the CFI offset is larger than a single text node length, when those multiple text nodes are separated by elements filtered out by the blacklist. We assume that those elements split a single text node into multiple pieces.

The tests replicate this by using a cfi that points to the last part of a single text node that appears to be split into three text nodes.